### PR TITLE
Fix two regex match issues

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ async function main() {
     if (selected && selected?.length > 1) {
       for (let block of selected) {
         if (block?.uuid) {
-          const regx = new RegExp(`^(${tasks.join('|')})`, 'gm');
+          const regx = new RegExp(`^(${tasks.join('|')}) `, 'gm');
           let content = regx.test(block.content)
             ? block.content.replace(regx, '').trimStart()
             : block.content;
@@ -73,7 +73,7 @@ async function main() {
     } else {
       const block = await logseq.Editor.getCurrentBlock();
       if (block?.uuid) {
-        const regx = new RegExp(`^(${tasks.join('|')})`, 'gm');
+        const regx = new RegExp(`^(${tasks.join('|')}) `, 'gm');
         let content = regx.test(block.content)
           ? block.content.replace(regx, '').trimStart()
           : block.content;

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ async function main() {
     if (selected && selected?.length > 1) {
       for (let block of selected) {
         if (block?.uuid) {
-          const regx = new RegExp(`^${tasks.join('|')}`, 'gm');
+          const regx = new RegExp(`^(${tasks.join('|')})`, 'gm');
           let content = regx.test(block.content)
             ? block.content.replace(regx, '').trimStart()
             : block.content;
@@ -73,7 +73,7 @@ async function main() {
     } else {
       const block = await logseq.Editor.getCurrentBlock();
       if (block?.uuid) {
-        const regx = new RegExp(`^${tasks.join('|')}`, 'gm');
+        const regx = new RegExp(`^(${tasks.join('|')})`, 'gm');
         let content = regx.test(block.content)
           ? block.content.replace(regx, '').trimStart()
           : block.content;


### PR DESCRIPTION
### Case 1 Marks like "DOING", "DONE" are removed when changing the task status

```markdown
TODO Remove `TODO` for `DOING` task.
```
Press `ctrl + 0` and it will become
```markdown
Remove `` for `` task.
```

fix: dcd3d15263e85b12a28f5b26b9406b52891879de
Using regex like `^(TODO|DOING)` instead of `^TODO|DOING`

### Case 2. Word partially start with uppercase mark will be wrongly changed

```markdown
LATERAL WALL
```
Press `ctrl + 1`, it will change to
```markdown
TODOAL WALL
```

fix: 8a10eb34b77be4174b7981e621194b1d94979210
Add an extra space to check.
